### PR TITLE
Scope test for slf4j-log4j12 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,10 @@
       <version>1.6.1</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.6.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
       <version>1.6.1</version>
     </dependency>
     <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.6.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,6 @@
       <version>1.6.1</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.6.1</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>


### PR DESCRIPTION
We're currently using log4j-over-slf4j in our project to handle some other projects that use log4j, which doesn't work if slf4j-log4j12 is also in the classpath.  Would you consider moving it to scope test where it seems to be used?

Best,
Paul
